### PR TITLE
Suppress SSL certificate errors.

### DIFF
--- a/httpproxy.py
+++ b/httpproxy.py
@@ -20,6 +20,7 @@ import logging
 import socket
 import SocketServer
 import ssl
+import sys
 import time
 import urlparse
 
@@ -283,6 +284,18 @@ class HttpProxyServer(SocketServer.ThreadingMixIn,
 
   def get_active_request_count(self):
     return self.num_active_requests
+
+  def handle_error(self, request, client_address):
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    exceptions_to_ignore = [
+        'tlsv1 alert unknown ca',
+        'sslv3 alert certificate unknown',
+    ]
+    for exception_to_ignore in exceptions_to_ignore:
+      if exception_to_ignore in str(exc_value):
+        return
+
+    raise
 
 
 class HttpsProxyServer(HttpProxyServer):


### PR DESCRIPTION
By default, each SSL certificate error generates a full traceback. This is pretty pointless, since we know that all SSL requests are going to have certificate errors.
