### PR TITLE
Bug fix in should_generate_certs option

### DIFF
--- a/replay.py
+++ b/replay.py
@@ -129,7 +129,7 @@ def AddWebProxy(server_manager, options, host, real_dns_lookup, http_archive):
   if options.ssl:
     if options.should_generate_certs:
       server_manager.Append(
-          httpproxy.HttpsProxyServer, archive_fetch, custom_handlers,
+          httpproxy.HttpsProxyServer, real_dns_lookup, archive_fetch, custom_handlers,
           options.https_root_ca_cert_path, host=host, port=options.ssl_port,
           use_delays=options.use_server_delay, **options.shaping_http)
     else:


### PR DESCRIPTION
Using should_generate_certs option cause the tool to fetch the host certificate with the default system DNS server which is the web-page-replay tool itself.

The fix resolve the host's IP first, and then trying to fetch the server's certificate.