### PR TITLE
Fixing typos

### DIFF
--- a/third_party/dns/name.py
+++ b/third_party/dns/name.py
@@ -176,7 +176,7 @@ class Name(object):
     def fullcompare(self, other):
         """Compare two names, returning a 3-tuple (relation, order, nlabels).
 
-        I{relation} describes the relation ship beween the names,
+        I{relation} describes the relation ship between the names,
         and is one of: dns.name.NAMERELN_NONE,
         dns.name.NAMERELN_SUPERDOMAIN, dns.name.NAMERELN_SUBDOMAIN,
         dns.name.NAMERELN_EQUAL, or dns.name.NAMERELN_COMMONANCESTOR

--- a/trafficshaper_test.py
+++ b/trafficshaper_test.py
@@ -67,7 +67,7 @@ class TimedTcpHandler(SocketServer.StreamRequestHandler):
 
   It can respond with the number of bytes specified in the request.
   The request looks like:
-    request_data -> RESPONSE_SIZE_KEY num_reponse_bytes '\n' ANY_DATA
+    request_data -> RESPONSE_SIZE_KEY num_response_bytes '\n' ANY_DATA
   """
 
   def handle(self):


### PR DESCRIPTION
Fixing typos for some misspellings
third_party/dns/name.py beween -> between
trafficshaper_test.py num_reponse_bytes -> num_response_bytes

Signed-off-by: dayoung.shin <dayoung.shin@samsung.com>