### PR TITLE
Always include a subjectAltName and extendedKeyUsage extension in certs

### DIFF
--- a/certutils.py
+++ b/certutils.py
@@ -130,8 +130,6 @@ def generate_dummy_ca_cert(subject='_WebPageReplayCert'):
   ca_cert.set_pubkey(key)
   ca_cert.add_extensions([
       crypto.X509Extension('basicConstraints', True, 'CA:TRUE'),
-      crypto.X509Extension('subjectAltName', False, 'DNS:' + subject),
-      crypto.X509Extension('nsCertType', True, 'sslCA'),
       crypto.X509Extension('extendedKeyUsage', True,
                            ('serverAuth,clientAuth,emailProtection,'
                             'timeStamping,msCodeInd,msCodeCom,msCTLSign,'
@@ -230,20 +228,13 @@ def generate_cert(root_ca_cert_str, server_cert_str, server_host):
   Returns:
     a PEM formatted certificate string
   """
-  EXTENSION_WHITELIST = set(['subjectAltName'])
-
   if openssl_import_error:
     raise openssl_import_error  # pylint: disable=raising-bad-type
 
   common_name = server_host
-  reused_extensions = []
   if server_cert_str:
     original_cert = load_cert(server_cert_str)
     common_name = original_cert.get_subject().commonName
-    for i in xrange(original_cert.get_extension_count()):
-      original_cert_extension = original_cert.get_extension(i)
-      if original_cert_extension.get_short_name() in EXTENSION_WHITELIST:
-        reused_extensions.append(original_cert_extension)
 
   ca_cert = load_cert(root_ca_cert_str)
   ca_key = load_privatekey(root_ca_cert_str)
@@ -255,7 +246,10 @@ def generate_cert(root_ca_cert_str, server_cert_str, server_host):
   cert.set_issuer(ca_cert.get_subject())
   cert.set_serial_number(int(time.time()*10000))
   cert.set_pubkey(ca_key)
-  cert.add_extensions(reused_extensions)
+  cert.add_extensions([
+    crypto.X509Extension('subjectAltName', False, 'DNS:' + server_host),
+    crypto.X509Extension('extendedKeyUsage', False, 'serverAuth,clientAuth'),
+  ])
   cert.sign(ca_key, 'sha256')
 
   return _dump_cert(cert)

--- a/certutils_test.py
+++ b/certutils_test.py
@@ -125,10 +125,15 @@ class CertutilsTest(unittest.TestCase):
     with open(ca_cert_path, 'r') as ca_cert_file:
       ca_cert_str = ca_cert_file.read()
     cert_string = certutils.generate_cert(ca_cert_str, cert_string,
-                                          'host')
+                                          'host.com')
     cert = certutils.load_cert(cert_string)
     self.assertEqual(issuer, cert.get_issuer().commonName)
     self.assertEqual(subject, cert.get_subject().commonName)
+    self.assertEqual(2, cert.get_extension_count())
+    self.assertEqual(b"subjectAltName", cert.get_extension(0).get_short_name())
+    self.assertEqual(b"extendedKeyUsage",
+                     cert.get_extension(1).get_short_name())
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The existing logic attempts to copy the subjectAltName from the existing
cert, if any is provided, but otherwise leaves it absent. It also omits
any other extensions.

This means that if no certificate is supplied to copy from, no
subjectAltName will be present on the leaf cert, which means it doesn't
work for clients that require the SAN always be present (because it's
the only unambiguous way to represent the hostname the cert is for).

This also updates the leaf to include the extendedKeyUsage of serverAuth
and clientAuth. Browsers currently have 'legacy' behaviours in which
they assume a certificate lacking an EKU is intended to be used as a
server certificate, but are working to always require it. This minimizes
any future compatibility risk.

In doing so, this removes the concept of the EXTENSION_WHITELIST added.
This is because copying extensions generically can be harmful, because
it depends on the context of the dummy cert. For example, copying
extensions like keyUsage or the TLS Feature Extension (aka OCSP
Must-Staple) would be actively harmful if WPR did not support the
ciphersuites used (in the case of keyUsage) or OCSP stapling (in the
case of TLS feature extension).