### PR TITLE
Explicitly set the version to X.509v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ code](https://docs.google.com/document/d/1cehHn3Lig7UYw_7pqQJjkbPTV3kS11EYwjKO-6
 If you find issues with the project, you can file issues on this repo.
 If you want to do more and contribute code to help the project evolve,
 check out our [contribution
-guidelines](documentation/Contributing.md).
+guidelines](documentation/Contributing.md). 

--- a/certutils.py
+++ b/certutils.py
@@ -240,6 +240,7 @@ def generate_cert(root_ca_cert_str, server_cert_str, server_host):
   ca_key = load_privatekey(root_ca_cert_str)
 
   cert = crypto.X509()
+  cert.set_version(2)
   cert.get_subject().CN = common_name
   cert.gmtime_adj_notBefore(-60 * 60)
   cert.gmtime_adj_notAfter(60 * 60 * 24 * 30)

--- a/certutils_test.py
+++ b/certutils_test.py
@@ -129,6 +129,7 @@ class CertutilsTest(unittest.TestCase):
     cert = certutils.load_cert(cert_string)
     self.assertEqual(issuer, cert.get_issuer().commonName)
     self.assertEqual(subject, cert.get_subject().commonName)
+    self.assertEqual(2, cert.get_version())
     self.assertEqual(2, cert.get_extension_count())
     self.assertEqual(b"subjectAltName", cert.get_extension(0).get_short_name())
     self.assertEqual(b"extendedKeyUsage",


### PR DESCRIPTION
As extensions are now included in the certificate, explicitly indicate
that it is a v3 certificate and not a v1 certificate (v1/v2 does not
include extensions).

Note that because X.509 is 0-based for the version, set_version(2)
indicates V3 certificates.